### PR TITLE
feat: SOL-1764 | Add canonical to payload

### DIFF
--- a/src/Core/Bus/ArticleEvent.php
+++ b/src/Core/Bus/ArticleEvent.php
@@ -209,6 +209,12 @@ class ArticleEvent
                     'value' => wp_get_canonical_url($post_ID),
                 ],
             ],
+            'canonical' => [
+                [
+                    'culture' => ringier_getLocale(),
+                    'value' => Utils::get_canonical_url($post_ID),
+                ],
+            ],
             'title' => [
                 [
                     'culture' => ringier_getLocale(),

--- a/src/Core/Utils.php
+++ b/src/Core/Utils.php
@@ -758,4 +758,32 @@ class Utils
     {
         return get_transient("user_just_created_{$user_id}") === true;
     }
+
+    /**
+     * Returns the canonical URL for a post.
+     *
+     * When the post is the same as the current requested page the function will handle the
+     * pagination arguments too.
+     *
+     * @param int|null $post_id
+     *
+     * @return string The canonical URL
+     */
+    public static function get_canonical_url(?int $post_id): string
+    {
+        $post = get_post($post_id);
+
+        // If Yoast is active and has overridden canonical URL
+        if (has_filter('wpseo_canonical')) {
+            $yoast_canonical = apply_filters('wpseo_canonical', false, $post);
+            if (is_string($yoast_canonical) && !empty($yoast_canonical)) {
+                return $yoast_canonical;
+            }
+        }
+
+        $canonical = wp_get_canonical_url($post);
+
+        return is_string($canonical) ? $canonical : '';
+    }
+
 }


### PR DESCRIPTION
- [JIRA Ticket here](https://oneafricamedia.atlassian.net/browse/SOL-1764)

E.g:
```json
"canonical": [
            {
                "culture": "en_US",
                "value": "https://domain.com/discover/article-slug"
            }
        ]
```
- Will first query the canonical hook from Yoast to see if anyone has set a custom canonical
- If no Yoast, defaults to WordPress' default `wp_get_canonical_url` - [reference here](https://developer.wordpress.org/reference/functions/wp_get_canonical_url/)