### PR TITLE
feat: SOL-2585 | Add resume capability to batch article sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (dependency) Fully remove Timber/Twig
 
 
+## [3.5.1] - 2026-01-29 ##
+
+### Added ###
+* (UI) Added **Resume from ID** functionality to the Batch Article Sync tool, allowing users to continue interrupted syncs from a specific Article ID.
+
+### Changed ###
+* (UI) Updated the sync status message to clarify when a sync is resuming versus starting fresh.
+
+
 ## [3.5.0] - 2026-01-21 ##
 
 ### Added ###

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Tags:** ringier, bus, api, cde   
 **Requires at least:** 6.0  
 **Tested up to:** 6.9  
-**Stable tag:** 3.5.0  
+**Stable tag:** 3.5.1  
 **Requires PHP:** 8.1  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/assets/js/sync-tools.js
+++ b/assets/js/sync-tools.js
@@ -154,6 +154,11 @@ jQuery(document).ready(function ($) {
     function syncArticles() {
         const selectedType = $('input[name="bus_sync_post_type"]:checked').val();
 
+        // Get the resume ID from the input box
+        const startFromIdInput = $('#bus_sync_start_id').val();
+        // If input is empty, default to 0 (Newest). If set, parse as Integer.
+        let initialCursor = startFromIdInput ? parseInt(startFromIdInput, 10) : 0;
+
         if (!selectedType) {
             alert('Please select a post type.');
             return;
@@ -161,8 +166,14 @@ jQuery(document).ready(function ($) {
 
         let syncedCount = 0;
         progressDivArticle.show();
+
+        // Update UI message to confirm where we are starting
+        let startMsg = initialCursor > 0
+            ? `Resuming sync from last known ID <strong>${initialCursor}</strong>...`
+            : `Starting fresh sync (Newest First)...`;
+
         progressDivArticle.html(`
-            <h3>Starting article sync (Recent First)...</h3>
+            <h3>${startMsg}</h3>
             <p><strong>Type:</strong> ${selectedType}</p>
             <p style="font-weight: bold; color: #0073aa;">Please do NOT close this window.</p>
             <hr />
@@ -173,7 +184,6 @@ jQuery(document).ready(function ($) {
             $.post(SyncAuthorsAjax.ajax_url, {
                 action: 'sync_articles',
                 last_id: lastIdCursor,
-                // Send array as the PHP backend expects 'post_types' array
                 post_types: [selectedType]
             }, function (response) {
                 if (response.success && response.data) {
@@ -184,7 +194,7 @@ jQuery(document).ready(function ($) {
                             <hr />
                             <h3>Article Sync Complete:</h3>
                             <ul>
-                                <li><strong>${syncedCount}</strong> articles successfully synced.</li>
+                                <li><strong>${syncedCount}</strong> articles successfully synced in this session.</li>
                             </ul>
                             <strong style="color: green;">Process finished.</strong>
                         `);
@@ -202,7 +212,8 @@ jQuery(document).ready(function ($) {
             });
         }
 
-        syncNextArticle(0);
+        // Start the loop with the ID from the input box (or 0)
+        syncNextArticle(initialCursor);
     }
 
     $('#sync-authors-button').on('click', function () {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ringier, wkhayrattee
 Tags: ringier, bus, api, cde
 Requires at least: 6.0
 Tested up to: 6.9
-Stable tag: 3.5.0
+Stable tag: 3.5.1
 Requires PHP: 8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -161,6 +161,15 @@ This plugin requires *PHP version >= 8.1*.
 
 == Changelog ==
 
+### [3.5.1] - 2026-01-29 ###
+
+#### Added ####
+* (UI) Added **Resume from ID** functionality to the Batch Article Sync tool, allowing users to continue interrupted syncs from a specific Article ID.
+
+#### Changed ####
+* (UI) Updated the sync status message to clarify when a sync is resuming versus starting fresh.
+
+
 ### [3.5.0] - 2026-01-21 ###
 
 #### Added ####
@@ -176,6 +185,17 @@ This plugin requires *PHP version >= 8.1*.
 * (code) Major refactor of the `ArticleEvent` class to remove 3rd-party dependencies in favor of 100% native WP code:
   * Removed `GuzzleHttp\Client` in favor of native `wp_remote_post()`.
   * Removed `AuthenticationInterface` dependency; now uses `BusTokenManager` directly.
+
+
+### [3.4.1] - 2025-12-02 ###
+
+#### Added ####
+* (code) Added a check to see if the Ringier Author plugin is enabled
+  * If yes, only send events for authors that have their public profile set to ENABLED
+  * If that plugin is not present or disabled, it's business as usual
+
+#### Fixed ####
+* (payload) TopicEvents: title, slug and url should be array of objects
 
 
 ### [3.4.0] - 2025-07-02 ###

--- a/ringier-bus.php
+++ b/ringier-bus.php
@@ -10,7 +10,7 @@
  * Plugin Name: Ringier Bus
  * Plugin URI: https://github.com/RingierIMU/mkt-plugin-wordpress-bus
  * Description: A plugin to push events to Ringier CDE via the BUS API whenever an article is created, updated or deleted
- * Version: 3.5.0
+ * Version: 3.5.1
  * Requires at least: 6.0
  * Author: Ringier SA, Wasseem Khayrattee
  * Author URI: https://www.ringier.com/
@@ -49,7 +49,7 @@ if (!function_exists('add_action')) {
  * Some global constants for our use-case
  */
 define('RINGIER_BUS_DS', DIRECTORY_SEPARATOR);
-define('RINGIER_BUS_PLUGIN_VERSION', '3.5.0');
+define('RINGIER_BUS_PLUGIN_VERSION', '3.5.1');
 define('RINGIER_BUS_PLUGIN_MINIMUM_WP_VERSION', '6.0');
 define('RINGIER_BUS_PLUGIN_DIR_URL', plugin_dir_url(__FILE__)); //has trailing slash at end
 define('RINGIER_BUS_PLUGIN_DIR', plugin_dir_path(__FILE__)); //has trailing slash at end

--- a/views/admin/admin-sync-page.php
+++ b/views/admin/admin-sync-page.php
@@ -93,15 +93,23 @@ $exclude = [
 
     <div class="post-types-selector" style="margin-bottom: 15px; background: #fff; padding: 15px; border: 1px solid #ccd0d4;">
         <?php foreach ($post_types as $pt): ?>
-            <?php if (in_array($pt->name, $exclude)) {
-                continue;
-            } ?>
+            <?php if (in_array($pt->name, $exclude)) continue; ?>
             <label style="margin-right: 15px; display: inline-block; margin-bottom: 5px;">
                 <input type="radio" name="bus_sync_post_type" value="<?php echo esc_attr($pt->name); ?>"
-                    <?php checked($pt->name, 'post'); // Default to 'post' checked?> />
+                    <?php checked($pt->name, 'post'); ?> />
                 <?php echo esc_html($pt->label); ?> (<code><?php echo esc_html($pt->name); ?></code>)
             </label>
         <?php endforeach; ?>
+
+        <hr style="margin: 10px 0; border: 0; border-top: 1px solid #eee;" />
+
+        <label for="bus_sync_start_id" style="font-weight: bold;">
+            Resume from ID (Optional):
+        </label>
+        <input type="number" id="bus_sync_start_id" placeholder="e.g. 16878" class="small-text" style="margin-left: 5px;width:100px;">
+        <p class="description" style="display:inline-block; margin-left: 5px;">
+            (Leave empty to start from the newest. Enter the <strong>last synced ID</strong> to resume.)
+        </p>
     </div>
 
     <button id="sync-articles-button" class="button">Sync Selected Articles</button>


### PR DESCRIPTION
feat: add resume capability to batch article sync:
- Added 'Resume from ID' input field to the Batch Article Sync tool
- Updated JavaScript logic to initialize the cursor with the user-provided ID
- Improved UI status messages to clearly indicate resume state
- Enables continuing interrupted sync operations on large datasets without restarting