### PR TITLE
chore: SOL-2580 | Replace Yoast SEO metadata methods with native WP_Post properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (dependency) Fully remove Timber/Twig
 
 
+## [3.5.2] - 2026-02-04 ##
+
+### Changed ###
+* (code) Refactored `getOgArticlePublishedDate` and `getOgArticleModifiedDate` to use native `WP_Post` properties instead of Yoast SEO Indexables. This ensures the API uses the database "Source of Truth" and avoids data cross-contamination when posts share slugs with historical attachments.
+* (code) Hardened `Utils::formatDate` to handle null or "zeroed" database timestamps (`0000-00-00 00:00:00`), ensuring strict RFC3339 compliance.
+
+
 ## [3.5.1] - 2026-01-29 ##
 
 ### Added ###

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Tags:** ringier, bus, api, cde   
 **Requires at least:** 6.0  
 **Tested up to:** 6.9  
-**Stable tag:** 3.5.1  
+**Stable tag:** 3.5.2  
 **Requires PHP:** 8.1  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ringier, wkhayrattee
 Tags: ringier, bus, api, cde
 Requires at least: 6.0
 Tested up to: 6.9
-Stable tag: 3.5.1
+Stable tag: 3.5.2
 Requires PHP: 8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -160,6 +160,13 @@ This plugin requires *PHP version >= 8.1*.
 2. On article dashboard, you can select a value for "Article Lifetime"
 
 == Changelog ==
+
+### [3.5.2] - 2026-02-04 ###
+
+#### Changed ####
+* (code) Refactored `getOgArticlePublishedDate` and `getOgArticleModifiedDate` to use native `WP_Post` properties instead of Yoast SEO Indexables. This ensures the API uses the database "Source of Truth" and avoids data cross-contamination when posts share slugs with historical attachments.
+* (code) Hardened `Utils::formatDate` to handle null or "zeroed" database timestamps (`0000-00-00 00:00:00`), ensuring strict RFC3339 compliance.
+
 
 ### [3.5.1] - 2026-01-29 ###
 

--- a/ringier-bus.php
+++ b/ringier-bus.php
@@ -10,7 +10,7 @@
  * Plugin Name: Ringier Bus
  * Plugin URI: https://github.com/RingierIMU/mkt-plugin-wordpress-bus
  * Description: A plugin to push events to Ringier CDE via the BUS API whenever an article is created, updated or deleted
- * Version: 3.5.1
+ * Version: 3.5.2
  * Requires at least: 6.0
  * Author: Ringier SA, Wasseem Khayrattee
  * Author URI: https://www.ringier.com/
@@ -49,7 +49,7 @@ if (!function_exists('add_action')) {
  * Some global constants for our use-case
  */
 define('RINGIER_BUS_DS', DIRECTORY_SEPARATOR);
-define('RINGIER_BUS_PLUGIN_VERSION', '3.5.1');
+define('RINGIER_BUS_PLUGIN_VERSION', '3.5.2');
 define('RINGIER_BUS_PLUGIN_MINIMUM_WP_VERSION', '6.0');
 define('RINGIER_BUS_PLUGIN_DIR_URL', plugin_dir_url(__FILE__)); //has trailing slash at end
 define('RINGIER_BUS_PLUGIN_DIR', plugin_dir_path(__FILE__)); //has trailing slash at end

--- a/src/Core/Bus/ArticleEvent.php
+++ b/src/Core/Bus/ArticleEvent.php
@@ -773,13 +773,14 @@ class ArticleEvent
      *
      * @return string
      */
-    private function getOgArticleModifiedDate(int $post_ID, \WP_Post $post)
+    private function getOgArticleModifiedDate(int $post_ID, \WP_Post $post): string
     {
-        if (class_exists('YoastSEO') && (is_object(YoastSEO()))) {
-            return YoastSEO()->meta->for_post($post_ID)->open_graph_article_modified_time;
-        }
+        // Ensure we have a valid GMT modified date; fallback to local modified if GMT is empty
+        $date = !empty($post->post_modified_gmt) && $post->post_modified_gmt !== '0000-00-00 00:00:00'
+            ? $post->post_modified_gmt
+            : $post->post_modified;
 
-        return Utils::formatDate($post->post_modified_gmt);
+        return Utils::formatDate($date);
     }
 
     /**
@@ -791,13 +792,14 @@ class ArticleEvent
      *
      * @return string
      */
-    private function getOgArticlePublishedDate(int $post_ID, \WP_Post $post)
+    private function getOgArticlePublishedDate(int $post_ID, \WP_Post $post): string
     {
-        if (class_exists('YoastSEO') && (is_object(YoastSEO()))) {
-            return YoastSEO()->meta->for_post($post_ID)->open_graph_article_published_time;
-        }
+        // Ensure we have a valid GMT date; fallback to local date if GMT is empty
+        $date = !empty($post->post_date_gmt) && $post->post_date_gmt !== '0000-00-00 00:00:00'
+            ? $post->post_date_gmt
+            : $post->post_date;
 
-        return Utils::formatDate($post->post_date_gmt);
+        return Utils::formatDate($date);
     }
 
     /**

--- a/src/Core/Utils.php
+++ b/src/Core/Utils.php
@@ -440,12 +440,22 @@ class Utils
      *
      * @return string
      */
-    public static function formatDate($date, $format = \DATE_RFC3339): string
+    public static function formatDate($date, string $format = \DATE_RFC3339): string
     {
+        // Handle empty or null inputs immediately
+        if (empty($date) || $date === '0000-00-00 00:00:00') {
+            return '';
+        }
+
         $immutable_date = \date_create_immutable_from_format('Y-m-d H:i:s', $date, new \DateTimeZone('UTC'));
 
         if (!$immutable_date) {
-            return $date;
+            // Try a generic parse as a final fallback before giving up
+            try {
+                $immutable_date = new \DateTimeImmutable($date, new \DateTimeZone('UTC'));
+            } catch (\Exception $e) {
+                return $date;
+            }
         }
 
         return $immutable_date->format($format);


### PR DESCRIPTION
- Fixes issue where posts shared slugs with older attachments, causing Yoast to return old dates for new posts
- Standardize date formatting to use GMT/UTC natively from the database
- update meta data for new release 3.5.2