### PR TITLE
SOL-2851 | Gratka event AuthorUpdate issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased] ##
+## [4.0.1] - 2026-04-16 ##
+
+### Fixed ###
+* (bug) `AuthorUpdated` event not dispatched when `ringier-author-addon` is active — `shouldDispatchAuthorEvent()` was evaluated inside `dispatchAuthorEvent()`, after the duplicate-guard transient was already set. If the meta `ringier_show_author_profile_page` was `'off'` or unset at the time of the first `profile_update` (before `save_data_onsubmit` had written the new value), the transient was stamped with a stale result, blocking all subsequent `profile_update` calls from dispatching. Fixed by moving the `shouldDispatchAuthorEvent()` check to before `set_transient()` in `triggerUserUpdatedEvent()` — if the check returns `false`, the method returns early without touching the transient, leaving subsequent calls free to dispatch once the correct meta value is in the DB.
 
 
 ## [4.0.0] - 2026-03-02 ##

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 **Contributors:** [RingierSA](https://profiles.wordpress.org/ringier/), [wkhayrattee](https://profiles.wordpress.org/wkhayrattee/)  
 **Tags:** ringier, bus, api, cde   
 **Requires at least:** 6.0  
-**Tested up to:** 6.9  
-**Stable tag:** 4.0.0  
+**Tested up to:** 6.9.4  
+**Stable tag:** 4.0.1  
 **Requires PHP:** 8.1  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: ringier, wkhayrattee
 Tags: ringier, bus, api, cde
 Requires at least: 6.0
-Tested up to: 6.9
-Stable tag: 4.0.0
+Tested up to: 6.9.4
+Stable tag: 4.0.1
 Requires PHP: 8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -160,6 +160,11 @@ This plugin requires *PHP version >= 8.1*.
 2. On article dashboard, you can select a value for "Article Lifetime"
 
 == Changelog ==
+
+### [4.0.1] - 2026-04-16 ###
+
+#### Fixed ####
+* (bug) `AuthorUpdated` event not dispatched when `ringier-author-addon` is active — `shouldDispatchAuthorEvent()` was evaluated inside `dispatchAuthorEvent()`, after the duplicate-guard transient was already set. If the meta `ringier_show_author_profile_page` was `'off'` or unset at the time of the first `profile_update` (before `save_data_onsubmit` had written the new value), the transient was stamped with a stale result, blocking all subsequent `profile_update` calls from dispatching. Fixed by moving the `shouldDispatchAuthorEvent()` check to before `set_transient()` in `triggerUserUpdatedEvent()` — if the check returns `false`, the method returns early without touching the transient, leaving subsequent calls free to dispatch once the correct meta value is in the DB.
 
 ### [4.0.0] - 2026-03-02 ###
 

--- a/ringier-bus.php
+++ b/ringier-bus.php
@@ -10,7 +10,7 @@
  * Plugin Name: Ringier Bus
  * Plugin URI: https://github.com/RingierIMU/mkt-plugin-wordpress-bus
  * Description: A plugin to push events to Ringier CDE via the BUS API whenever an article is created, updated or deleted
- * Version: 4.0.0
+ * Version: 4.0.1
  * Requires at least: 6.0
  * Author: Ringier SA, Wasseem Khayrattee
  * Author URI: https://www.ringier.com/
@@ -49,7 +49,7 @@ if (!function_exists('add_action')) {
  * Some global constants for our use-case
  */
 define('RINGIER_BUS_DS', DIRECTORY_SEPARATOR);
-define('RINGIER_BUS_PLUGIN_VERSION', '4.0.0');
+define('RINGIER_BUS_PLUGIN_VERSION', '4.0.1');
 define('RINGIER_BUS_PLUGIN_MINIMUM_WP_VERSION', '6.0');
 define('RINGIER_BUS_PLUGIN_DIR_URL', plugin_dir_url(__FILE__)); //has trailing slash at end
 define('RINGIER_BUS_PLUGIN_DIR', plugin_dir_path(__FILE__)); //has trailing slash at end

--- a/src/Core/Bus/BusHelper.php
+++ b/src/Core/Bus/BusHelper.php
@@ -276,6 +276,26 @@ class BusHelper
         if (get_transient('bus_user_update_' . $user_id)) {
             return;
         }
+
+        /*
+         * Check shouldDispatchAuthorEvent BEFORE setting the transient.
+         *
+         * When the Ringier Author Addon is active, META_SHOW_PROFILE_PAGE_KEY is saved
+         * by save_data_onsubmit (hooked to personal_options_update / edit_user_profile_update),
+         * which fires AFTER profile_update. This means:
+         *   1. profile_update fires (from edit_user) → we check the meta → old/unset value → false
+         *   2. save_data_onsubmit runs → saves the new meta value
+         *   3. save_data_onsubmit calls wp_update_user() → fires another profile_update
+         *
+         * If we set the transient in step 1, step 3's profile_update is blocked by it and the
+         * AuthorUpdated event is never dispatched, even when the admin enabled the author profile.
+         *
+         * By returning here WITHOUT setting the transient, step 3 is free to dispatch the event.
+         */
+        if (!self::shouldDispatchAuthorEvent($user_id)) {
+            return;
+        }
+
         // Set a transient to mark this hook as processed for this user
         set_transient('bus_user_update_' . $user_id, true, 5); // 5 seconds validity
 


### PR DESCRIPTION
## Problem
AuthorUpdated events were not being dispatched on the Gratka blog which was using a non-standard WordPress profile save flow (AJAX), even when the "Show Profile Page" checkbox was enabled.

## Root cause
save_data_onsubmit saved META_SHOW_PROFILE_PAGE_KEY at the very end of the function. Before reaching that line it called wp_update_user(['nickname' => ...]), which internally fires profile_update. At that moment the Ringier Bus plugin reads META_SHOW_PROFILE_PAGE_KEY to gate dispatch — but the value hadn't been written yet, so it read the old/empty value and skipped the event. Once the meta was finally saved, no further profile_update calls followed, leaving the event permanently un-dispatched.

## Fix
Move the META_SHOW_PROFILE_PAGE_KEY update_user_meta call to the top of save_data_onsubmit, before wp_update_user(). The correct value is now in the DB when profile_update fires.

## Note
This fix works in tandem with a companion change in ringier-bus that prevents the duplicate-guard transient from being stamped prematurely (before shouldDispatchAuthorEvent is evaluated), which is what allows this second profile_update to reach the dispatch logic at all.

---

##Walk through of all possible cases:

  User with META_SHOW_PROFILE_PAGE_KEY = 'on' (already enabled, any blog):
  1. Call A (edit_user()): shouldDispatchAuthorEvent = 'on' → sets transient → dispatches ✓
  2. Call B (save_data_onsubmit's wp_update_user): transient is set → bails ✓ (no duplicate)

  User with META_SHOW_PROFILE_PAGE_KEY = 'off' → admin enables it, standard WP blog:
  1. Call A: shouldDispatchAuthorEvent = 'off' → returns, no transient set
  2. save_data_onsubmit: saves 'on' first (Fixed) → wp_update_user → Call B
  3. Call B: shouldDispatchAuthorEvent = 'on' → sets transient → dispatches ✓

  User with META_SHOW_PROFILE_PAGE_KEY = 'off' → stays 'off', standard WP blog:
  1. Call A: shouldDispatchAuthorEvent = 'off' → returns, no transient
  2. Call B: shouldDispatchAuthorEvent = 'off' → returns, no transient
  3. No dispatch ✓ (correct — profile page disabled)

  Blog WITHOUT ringier-author-addon at all:
  - shouldDispatchAuthorEvent always returns true (constant not defined)
  - Call A: sets transient → dispatches ✓
  - Behaviour identical to before the fix